### PR TITLE
fix: remove defunct svg viewer extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Note - not all of these may be to your taste! We have tried to include packages 
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - _Code formatter using prettier_
 - [Nextflow](https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow) - _Nextflow language support_
 - [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) - _Highlight columns in csv files in different colors_
-- [SVG Viewer](https://marketplace.visualstudio.com/items?itemName=cssho.vscode-svgviewer) - _Open and view SVG images_
 - [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) - _Show TODO, FIXME, etc. comment tags in a tree view_
 - [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) - _YAML Language Support by Red Hat, with built-in Kubernetes syntax support_
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+    "name": "nf-core-extensionpack",
+    "version": "0.4.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "nf-core-extensionpack",
+            "version": "0.4.0",
+            "engines": {
+                "vscode": "^1.53.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     ],
     "extensionPack": [
         "codezombiech.gitignore",
-        "cssho.vscode-svgviewer",
         "esbenp.prettier-vscode",
         "eamodio.gitlens",
         "EditorConfig.EditorConfig",


### PR DESCRIPTION
This removes the defunct svg-viewer extension.  As a part of this PR, I've also reviewed all other extensions to make sure none of the others are defunct. 

Closes nf-core#15