### PR TITLE
Remove some subjective extensions, add .gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "nf-core-extensionpack" extension pack will be docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.8.0
+
+- Add `codezombiech.gitignore`
+- Remove `oderwat.indent-rainbow`
+- Remove `streetsidesoftware.code-spell-checker`
+- Remove `Gruntfuggly.todo-tree`
+
 ## 0.7.0
 
 - Add `jebbs.markdown-extended`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add `codezombiech.gitignore`
 - Remove `oderwat.indent-rainbow`
 - Remove `streetsidesoftware.code-spell-checker`
-- Remove `Gruntfuggly.todo-tree`
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,21 @@ Note - not all of these may be to your taste! We have tried to include packages 
 ## Included extensions
 
 - [Apptainer/Singularity](https://marketplace.visualstudio.com/items?itemName=onnovalkering.vscode-singularity) - _Provides syntax highlighting for Apptainer/Singularity definition files_
-- [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) - _A basic spell checker that works well with camelCase code._
 - [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) - _Makes it easy to create, manage, and debug containerized applications_
 - [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) - _Support for [EditorConfig](https://editorconfig.org/) project files for code standardisation._
-- [indent-rainbow](https://marketplace.visualstudio.com/items?itemName=oderwat.indent-rainbow) - _Highlight indentation level, especially if inconsistent_
+- [gitignore](codezombiech.gitignore) - _Language support for .gitignore files_
+- [Markdown Extended](https://marketplace.visualstudio.com/items?itemName=jebbs.markdown-extended) - _Gives nice markdown previews, including admonitions - see [nf-core/website#2579](https://github.com/nf-core/website/pull/2579)_
 - [Nextflow](https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow) - _Nextflow language support_
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - _Code formatter using prettier_
 - [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) - _Highlight columns in csv files in different colors_
 - [Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) - _An extremely fast Python linter and code formatter, written in Rust._
-- [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) - _Show TODO, FIXME, etc. comment tags in a tree view_
 - [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) - _YAML Language Support by Red Hat, with built-in Kubernetes syntax support_
-- [Markdown Extended](https://marketplace.visualstudio.com/items?itemName=jebbs.markdown-extended) - _Gives nice markdown previews, including admonitions - see [nf-core/website#2579](https://github.com/nf-core/website/pull/2579)_
+
+Some extensions which are not included, but that many in the community find useful are:
+
+- [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) - _A basic spell checker that works well with camelCase code._
+- [indent-rainbow](https://marketplace.visualstudio.com/items?itemName=oderwat.indent-rainbow) - _Highlight indentation level, especially if inconsistent_
+- [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) - _Show TODO, FIXME, etc. comment tags in a tree view_
 
 Please create a GitHub issue if you can think of any others to recommend!
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Note - not all of these may be to your taste! We have tried to include packages 
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - _Code formatter using prettier_
 - [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) - _Highlight columns in csv files in different colors_
 - [Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) - _An extremely fast Python linter and code formatter, written in Rust._
+- [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) - _Show TODO, FIXME, etc. comment tags in a tree view_
 - [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) - _YAML Language Support by Red Hat, with built-in Kubernetes syntax support_
 
 Some extensions which are not included, but that many in the community find useful are:
 
 - [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) - _A basic spell checker that works well with camelCase code._
 - [indent-rainbow](https://marketplace.visualstudio.com/items?itemName=oderwat.indent-rainbow) - _Highlight indentation level, especially if inconsistent_
-- [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) - _Show TODO, FIXME, etc. comment tags in a tree view_
 
 Please create a GitHub issue if you can think of any others to recommend!
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/nf-core/vscode-extensionpack/issues"
     },
     "homepage": "https://nf-co.re",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "icon": "logo.png",
     "keywords": [
         "bioinformatics",
@@ -30,16 +30,14 @@
     ],
     "extensionPack": [
         "charliermarsh.ruff",
+        "codezombiech.gitignore",
         "EditorConfig.EditorConfig",
         "esbenp.prettier-vscode",
-        "Gruntfuggly.todo-tree",
+        "jebbs.markdown-extended",
         "mechatroner.rainbow-csv",
         "ms-azuretools.vscode-docker",
         "nextflow.nextflow",
-        "oderwat.indent-rainbow",
         "onnovalkering.vscode-singularity",
-        "redhat.vscode-yaml",
-        "streetsidesoftware.code-spell-checker",
-        "jebbs.markdown-extended"
+        "redhat.vscode-yaml"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "codezombiech.gitignore",
         "EditorConfig.EditorConfig",
         "esbenp.prettier-vscode",
+        "Gruntfuggly.todo-tree",
         "jebbs.markdown-extended",
         "mechatroner.rainbow-csv",
         "ms-azuretools.vscode-docker",


### PR DESCRIPTION
I find myself routinely disabling some extensions that we have in the extension pack, the indentation colouration primarily.

I think that we should keep the extension pack to only the really essential ones, so I've removed these and moved them to a section of the readme where they're still recommended but just no longer installed by default.

x-ref nextflow training: https://github.com/nextflow-io/training/pull/539#discussion_r1982102264